### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/crates/presentar-terminal/src/widgets/proportional_bar.rs
+++ b/crates/presentar-terminal/src/widgets/proportional_bar.rs
@@ -8,6 +8,7 @@ use presentar_core::{
     LayoutResult, Point, Rect, Size, TextStyle, TypeId, Widget,
 };
 use std::any::Any;
+use std::fmt::Write as _;
 use std::time::Duration;
 
 /// A single segment in a proportional bar.
@@ -243,9 +244,10 @@ impl Brick for ProportionalBar {
                 0.0
             };
             let Color { r, g, b, .. } = seg.color;
-            html.push_str(&format!(
+            let _ = write!(
+                html,
                 "<div style=\"width:{pct:.1}%;background:rgb({r},{g},{b})\"></div>"
-            ));
+            );
         }
         html.push_str("</div>");
         html


### PR DESCRIPTION
## Summary
- Replace `format_push_string` pattern with `std::fmt::Write` in `proportional_bar.rs` to pass `cargo clippy --workspace --lib --locked -- -D warnings` cleanly.

## Test plan
- [x] `cargo clippy --workspace --lib --locked -- -D warnings` passes with zero errors

Generated with Claude Code