### PR TITLE
fix: Cross-Platform workflow needs provable-contracts sibling checkout

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -25,6 +25,22 @@ jobs:
             features: minimal
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout provable-contracts (path dep)
+        uses: actions/checkout@v4
+        with:
+          repository: paiml/provable-contracts
+          path: provable-contracts
+
+      - name: Symlink provable-contracts for Cargo path deps
+        if: runner.os != 'Windows'
+        run: ln -sf "$GITHUB_WORKSPACE/provable-contracts" "$GITHUB_WORKSPACE/../provable-contracts"
+
+      - name: Symlink provable-contracts (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
+
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build


### PR DESCRIPTION
## Summary
Apply the same sibling-checkout pattern from nightly.yml to cross-platform.yml.

## Root cause
Workspace Cargo.toml references `provable-contracts-macros = { path = "../provable-contracts/crates/..." }`. Without the sibling checkout, cargo build fails:
```
failed to read `$WORK/provable-contracts/crates/provable-contracts-macros/Cargo.toml`
No such file or directory (os error 2)
```

## Fix
Adds checkout-inside-workspace + symlink (+ Windows Junction for matrix) steps. Matches the already-working pattern in nightly.yml.

Fixes #35
Refs paiml/infra#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)