### PR TITLE
fix: guard mouse capture bytes assertion for Windows

### DIFF
--- a/crates/presentar-core/build.rs
+++ b/crates/presentar-core/build.rs
@@ -8,28 +8,58 @@ fn main() {
         let cdir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("contracts");
         if let Ok(es) = std::fs::read_dir(&cdir) {
             #[derive(serde::Deserialize, Default)]
-            struct CY { #[serde(default)] equations: std::collections::BTreeMap<String, EY> }
+            struct CY {
+                #[serde(default)]
+                equations: std::collections::BTreeMap<String, EY>,
+            }
             #[derive(serde::Deserialize, Default)]
-            struct EY { #[serde(default)] preconditions: Vec<String>, #[serde(default)] postconditions: Vec<String> }
+            struct EY {
+                #[serde(default)]
+                preconditions: Vec<String>,
+                #[serde(default)]
+                postconditions: Vec<String>,
+            }
             let (mut tp, mut tq) = (0, 0);
             for e in es.flatten() {
                 let p = e.path();
-                if p.extension().and_then(|x| x.to_str()) != Some("yaml") { continue; }
-                if p.file_name().is_some_and(|n| n.to_string_lossy().contains("binding")) { continue; }
+                if p.extension().and_then(|x| x.to_str()) != Some("yaml") {
+                    continue;
+                }
+                if p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().contains("binding"))
+                {
+                    continue;
+                }
                 println!("cargo:rerun-if-changed={}", p.display());
-                let s = p.file_stem().and_then(|x| x.to_str()).unwrap_or("x").to_uppercase().replace('-', "_");
+                let s = p
+                    .file_stem()
+                    .and_then(|x| x.to_str())
+                    .unwrap_or("x")
+                    .to_uppercase()
+                    .replace('-', "_");
                 if let Ok(c) = std::fs::read_to_string(&p) {
                     if let Ok(y) = serde_yaml_ng::from_str::<CY>(&c) {
                         for (n, eq) in &y.equations {
-                            let k = format!("CONTRACT_{}_{}", s, n.to_uppercase().replace('-', "_"));
+                            let k =
+                                format!("CONTRACT_{}_{}", s, n.to_uppercase().replace('-', "_"));
                             if !eq.preconditions.is_empty() {
-                                println!("cargo:rustc-env={k}_PRE_COUNT={}", eq.preconditions.len());
-                                for (i, v) in eq.preconditions.iter().enumerate() { println!("cargo:rustc-env={k}_PRE_{i}={v}"); }
+                                println!(
+                                    "cargo:rustc-env={k}_PRE_COUNT={}",
+                                    eq.preconditions.len()
+                                );
+                                for (i, v) in eq.preconditions.iter().enumerate() {
+                                    println!("cargo:rustc-env={k}_PRE_{i}={v}");
+                                }
                                 tp += eq.preconditions.len();
                             }
                             if !eq.postconditions.is_empty() {
-                                println!("cargo:rustc-env={k}_POST_COUNT={}", eq.postconditions.len());
-                                for (i, v) in eq.postconditions.iter().enumerate() { println!("cargo:rustc-env={k}_POST_{i}={v}"); }
+                                println!(
+                                    "cargo:rustc-env={k}_POST_COUNT={}",
+                                    eq.postconditions.len()
+                                );
+                                for (i, v) in eq.postconditions.iter().enumerate() {
+                                    println!("cargo:rustc-env={k}_POST_{i}={v}");
+                                }
                                 tq += eq.postconditions.len();
                             }
                         }

--- a/crates/presentar-terminal/src/app_tests.rs
+++ b/crates/presentar-terminal/src/app_tests.rs
@@ -1195,9 +1195,13 @@ fn test_testable_backend_enable_mouse_capture() {
     assert!(!backend.is_mouse_captured());
     backend.enable_mouse_capture().unwrap();
     assert!(backend.is_mouse_captured());
-    // Verify escape sequence was written
-    let output = backend.into_writer();
-    assert!(!output.is_empty());
+    // Verify escape sequence was written (Unix only — on Windows, crossterm
+    // uses the Console API instead of writing ANSI escape sequences)
+    #[cfg(not(target_os = "windows"))]
+    {
+        let output = backend.into_writer();
+        assert!(!output.is_empty());
+    }
 }
 
 #[test]

--- a/crates/presentar/tests/contract_traits.rs
+++ b/crates/presentar/tests/contract_traits.rs
@@ -9,9 +9,9 @@
 //! Run with: `cargo test --test contract_traits`
 
 use provable_contracts::traits::{
-    ActivationKernelV1, AdamwKernelV1, AttentionKernelV1, CrossEntropyKernelV1,
-    FlashAttentionV1, GqaKernelV1, LayernormKernelV1, MatmulKernelV1, RmsnormKernelV1,
-    RopeKernelV1, SiluKernelV1, SoftmaxKernelV1, SwigluKernelV1,
+    ActivationKernelV1, AdamwKernelV1, AttentionKernelV1, CrossEntropyKernelV1, FlashAttentionV1,
+    GqaKernelV1, LayernormKernelV1, MatmulKernelV1, RmsnormKernelV1, RopeKernelV1, SiluKernelV1,
+    SoftmaxKernelV1, SwigluKernelV1,
 };
 
 /// Marker struct for reference scalar kernel implementations.
@@ -189,7 +189,10 @@ fn rmsnorm_kernel_v1_properties() {
     // out ≈ [3/3.5355, 4/3.5355] ≈ [0.8485, 1.1314]
     assert!(out.len() == 2);
     let rms_out = (out.iter().map(|v| v * v).sum::<f32>() / out.len() as f32).sqrt();
-    assert!((rms_out - 1.0).abs() < 1e-3, "rmsnorm output should have ~unit RMS");
+    assert!(
+        (rms_out - 1.0).abs() < 1e-3,
+        "rmsnorm output should have ~unit RMS"
+    );
 }
 
 #[test]
@@ -221,7 +224,10 @@ fn cross_entropy_kernel_v1_properties() {
     }
     // exp(log_softmax) should sum to 1
     let sum_exp: f32 = lsm.iter().map(|v| v.exp()).sum();
-    assert!((sum_exp - 1.0).abs() < 1e-5, "exp(log_softmax) must sum to 1");
+    assert!(
+        (sum_exp - 1.0).abs() < 1e-5,
+        "exp(log_softmax) must sum to 1"
+    );
 
     // cross_entropy with one-hot target
     let targets = vec![0.0, 0.0, 1.0];


### PR DESCRIPTION
## Summary
- Guards the bytes-written assertion in `test_testable_backend_enable_mouse_capture` with `#[cfg(not(target_os = "windows"))]`
- crossterm uses Win32 Console API on Windows instead of ANSI escapes, so no bytes are written to the `Vec<u8>` writer
- The `is_mouse_captured()` assertion already verifies correctness on all platforms
- Also applies `cargo fmt` to pre-existing formatting issues in `build.rs` and `contract_traits.rs`

Closes #37

## Five-Whys
1. output Vec is empty after enable_mouse_capture() on Windows
2. crossterm uses Windows Console API, not ANSI escape sequences
3. EnableMouseCapture dispatches to SetConsoleMode on Windows
4. Test assumes ANSI output (Unix behavior)
5. Main CI runs on Linux; cross-platform added later

## Test plan
- [ ] Cross-platform CI passes on Windows
- [ ] Main CI still passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)